### PR TITLE
Fixed incorrect stream to listen for restart command

### DIFF
--- a/src/plugins/run.ts
+++ b/src/plugins/run.ts
@@ -30,7 +30,7 @@ async function setup(build: PluginBuild, opts: RunOption) {
 }
 
 function onRestart(execute: ReturnType<typeof createRunner>) {
-  process.stdout.on("data", (buf) => {
+  process.stdin.on("data", (buf) => {
     const txt = buf.toString().trim();
     if (txt === "rs") {
       execute();


### PR DESCRIPTION
Hi, this commit fixes EBX run mode throwing `Error: read ENOTCONN` because it was listening on std-out stream instead of std-in. 

Full stacktrace:
```js
node:events:492
      throw er; // Unhandled 'error' event
      ^

Error: read ENOTCONN
    at tryReadStart (node:net:701:20)
    at Socket._read (node:net:716:5)
    at Readable.read (node:internal/streams/readable:715:12)
    at Socket.read (node:net:771:39)
    at resume_ (node:internal/streams/readable:1222:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on WriteStream instance at:
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4053,
  code: 'ENOTCONN',
  syscall: 'read'
```